### PR TITLE
Hiding Internals (Exception & Output properties)

### DIFF
--- a/RockLib.HealthChecks.All.sln
+++ b/RockLib.HealthChecks.All.sln
@@ -37,6 +37,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RockLib.HealthChecks.Client
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RockLib.HealthChecks.Client.Tests", "Tests\RockLib.HealthChecks.Client.Tests\RockLib.HealthChecks.Client.Tests.csproj", "{0E738824-8F16-4102-9876-9FC528F25240}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RockLib.HealthChecks.AspNetCore.ResponseWriter.Tests", "Tests\RockLib.HealthChecks.AspNetCore.ResponseWriter.Tests\RockLib.HealthChecks.AspNetCore.ResponseWriter.Tests.csproj", "{13F497C9-6BCC-4F41-85F7-8B9FD70047F8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -103,6 +105,10 @@ Global
 		{0E738824-8F16-4102-9876-9FC528F25240}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0E738824-8F16-4102-9876-9FC528F25240}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0E738824-8F16-4102-9876-9FC528F25240}.Release|Any CPU.Build.0 = Release|Any CPU
+		{13F497C9-6BCC-4F41-85F7-8B9FD70047F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{13F497C9-6BCC-4F41-85F7-8B9FD70047F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{13F497C9-6BCC-4F41-85F7-8B9FD70047F8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{13F497C9-6BCC-4F41-85F7-8B9FD70047F8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -117,6 +123,7 @@ Global
 		{4B767F60-0A55-4C43-B59F-F8D1EC17817E} = {077997E9-BD03-4F84-8B84-9047B35C1004}
 		{3E505D4D-1C8D-4F85-B8B0-4C2DDC11C9A0} = {077997E9-BD03-4F84-8B84-9047B35C1004}
 		{0E738824-8F16-4102-9876-9FC528F25240} = {EDD461DF-0B21-43ED-B082-C4F3698D284B}
+		{13F497C9-6BCC-4F41-85F7-8B9FD70047F8} = {EDD461DF-0B21-43ED-B082-C4F3698D284B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9BD2137B-45A2-4572-9151-93471F4F7CC9}

--- a/RockLib.HealthChecks.AspNetCore.ResponseWriter/RockLibHealthChecks.cs
+++ b/RockLib.HealthChecks.AspNetCore.ResponseWriter/RockLibHealthChecks.cs
@@ -23,6 +23,20 @@ namespace RockLib.HealthChecks.AspNetCore.ResponseWriter
         public static bool Indent { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the <see cref="ResponseWriter"/> delegate will display
+        /// the exception property in its JSON output.
+        /// The default is to hide the exception.
+        /// </summary>
+        public static bool ShowExceptions { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the <see cref="ResponseWriter"/> delegate will hide
+        /// the output property in its JSON output.
+        /// The default is to show the output.
+        /// </summary>
+        public static bool HideOutputs { get; set; }
+
+        /// <summary>
         /// Gets a delegate that maps its <see cref="HealthReport"/> parameter to the <see cref="HealthResponse"/>
         /// type and writes it to its <see cref="HttpContext.Response"/> parameter. Intended to be used to set the
         /// value of the <see cref="HealthCheckOptions.ResponseWriter"/> property.
@@ -35,20 +49,24 @@ namespace RockLib.HealthChecks.AspNetCore.ResponseWriter
             {
                 var entry = x.Value;
 
-                var result = new HealthCheckResult()
+                var result = new HealthCheckResult
                 {
                     ComponentName = GetComponentName(x.Key),
                     MeasurementName = GetMeasurementName(x.Key),
                     Status = MapStatus(entry.Status),
-                    Output = entry.Description,
-                    ["exception"] = entry.Exception?.ToString(),
                     ["duration"] = entry.Duration
                 };
+
+                if (ShowExceptions)
+                    result["exception"] = entry.Exception?.ToString();
+
+                if (!HideOutputs)
+                    result.Output = entry.Description;
 
                 // TODO: Detect collisions between entry.Exception/result.Output,
                 // entry.Description/result["description", or entry.Duration/result["duration"].
 
-                foreach (var data in entry.Data)
+            foreach (var data in entry.Data)
                     result[data.Key] = data.Value;
 
                 return result;

--- a/RockLib.HealthChecks.AspNetCore.ResponseWriter/RockLibHealthChecks.cs
+++ b/RockLib.HealthChecks.AspNetCore.ResponseWriter/RockLibHealthChecks.cs
@@ -27,7 +27,7 @@ namespace RockLib.HealthChecks.AspNetCore.ResponseWriter
         /// the exception property in its JSON output.
         /// The default is to hide the exception.
         /// </summary>
-        public static bool ShowExceptions { get; set; }
+        public static bool HideExceptions { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the <see cref="ResponseWriter"/> delegate will hide
@@ -57,7 +57,7 @@ namespace RockLib.HealthChecks.AspNetCore.ResponseWriter
                     ["duration"] = entry.Duration
                 };
 
-                if (ShowExceptions)
+                if (!HideExceptions)
                     result["exception"] = entry.Exception?.ToString();
 
                 if (!HideOutputs)

--- a/Tests/RockLib.HealthChecks.AspNetCore.ResponseWriter.Tests/ResponseWriterTests.cs
+++ b/Tests/RockLib.HealthChecks.AspNetCore.ResponseWriter.Tests/ResponseWriterTests.cs
@@ -1,0 +1,171 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using AutoFixture.Xunit2;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace RockLib.HealthChecks.AspNetCore.ResponseWriter.Tests
+{
+    public class ResponseWriterTests
+    {
+        [Theory]
+        [AutoData]
+        public async Task ResponseWriter_ShowException_Default_ShouldNotShowExceptionProperty(
+            HealthReport healthReport)
+        {
+            // Arrange
+            var httpContext = CreateHttpContext();
+
+            // Act
+            await RockLibHealthChecks.ResponseWriter(httpContext, healthReport);
+
+            // Assert
+            var jsonBody = await GetJsonBody(httpContext);
+            var healthCheckEntries = GetHealthCheckEntries(jsonBody);
+
+            healthCheckEntries
+                .Any(x => x["exception"] != null)
+                .Should()
+                .BeFalse();
+        }
+
+        [Theory]
+        [AutoData]
+        public async Task ResponseWriter_ShowException_SetToFalse_ShouldNotShowExceptionProperty(
+            HealthReport healthReport)
+        {
+            // Arrange
+            var httpContext = CreateHttpContext();
+            RockLibHealthChecks.ShowExceptions = false;
+
+            // Act
+            await RockLibHealthChecks.ResponseWriter(httpContext, healthReport);
+
+            // Assert
+            var jsonBody = await GetJsonBody(httpContext);
+            var healthCheckEntries = GetHealthCheckEntries(jsonBody);
+
+            healthCheckEntries
+                .Any(x => x["exception"] != null)
+                .Should()
+                .BeFalse();
+        }
+
+        [Theory]
+        [AutoData]
+        public async Task ResponseWriter_ShowException_SetToTrue_ShouldShowExceptionProperty(
+            HealthReport healthReport)
+        {
+            // Arrange
+            var httpContext = CreateHttpContext();
+            RockLibHealthChecks.ShowExceptions = true;
+
+            // Act
+            await RockLibHealthChecks.ResponseWriter(httpContext, healthReport);
+
+            // Assert
+            var jsonBody = await GetJsonBody(httpContext);
+            var healthCheckEntries = GetHealthCheckEntries(jsonBody);
+
+            healthCheckEntries
+                .Any(x => x["exception"] != null)
+                .Should()
+                .BeTrue();
+        }
+
+        [Theory]
+        [AutoData]
+        public async Task ResponseWriter_HideOutputs_Default_ShouldShowOutputProperty(
+            HealthReport healthReport)
+        {
+            // Arrange
+            var httpContext = CreateHttpContext();
+
+            // Act
+            await RockLibHealthChecks.ResponseWriter(httpContext, healthReport);
+
+            // Assert
+            var jsonBody = await GetJsonBody(httpContext);
+            var healthCheckEntries = GetHealthCheckEntries(jsonBody);
+
+            healthCheckEntries
+                .Any(x => x["output"] != null)
+                .Should()
+                .BeTrue();
+        }
+
+        [Theory]
+        [AutoData]
+        public async Task ResponseWriter_HideOutputs_SetToFalse_ShouldShowOutputProperty(
+            HealthReport healthReport)
+        {
+            // Arrange
+            var httpContext = CreateHttpContext();
+            RockLibHealthChecks.HideOutputs = false;
+
+            // Act
+            await RockLibHealthChecks.ResponseWriter(httpContext, healthReport);
+
+            // Assert
+            var jsonBody = await GetJsonBody(httpContext);
+            var healthCheckEntries = GetHealthCheckEntries(jsonBody);
+
+            healthCheckEntries
+                .Any(x => x["output"] != null)
+                .Should()
+                .BeTrue();
+        }
+
+        [Theory]
+        [AutoData]
+        public async Task ResponseWriter_HideOutputs_SetToTrue_ShouldHideOutputProperty(
+            HealthReport healthReport)
+        {
+            // Arrange
+            var httpContext = CreateHttpContext();
+            RockLibHealthChecks.HideOutputs = true;
+
+            // Act
+            await RockLibHealthChecks.ResponseWriter(httpContext, healthReport);
+
+            // Assert
+            var jsonBody = await GetJsonBody(httpContext);
+            var healthCheckEntries = GetHealthCheckEntries(jsonBody);
+
+            healthCheckEntries
+                .Any(x => x["output"] != null)
+                .Should()
+                .BeFalse();
+        }
+
+        private static IEnumerable<JToken> GetHealthCheckEntries(string jsonBody) => JObject.Parse(jsonBody)
+            .SelectToken("checks")
+            .Children()
+            .SelectMany(x => x.First);
+
+        private static async Task<string> GetJsonBody(DefaultHttpContext httpContext)
+        {
+            httpContext.Response.Body.Seek(0, SeekOrigin.Begin);
+
+            string bodyStr;
+            using (var reader = new StreamReader(httpContext.Response.Body))
+            {
+                bodyStr = await reader.ReadToEndAsync();
+            }
+
+            return bodyStr;
+        }
+
+        private static DefaultHttpContext CreateHttpContext()
+        {
+            var httpContext = new DefaultHttpContext();
+            httpContext.Response.Body = new MemoryStream();
+            return httpContext;
+        }
+    }
+}

--- a/Tests/RockLib.HealthChecks.AspNetCore.ResponseWriter.Tests/ResponseWriterTests.cs
+++ b/Tests/RockLib.HealthChecks.AspNetCore.ResponseWriter.Tests/ResponseWriterTests.cs
@@ -15,55 +15,11 @@ namespace RockLib.HealthChecks.AspNetCore.ResponseWriter.Tests
     {
         [Theory]
         [AutoData]
-        public async Task ResponseWriter_ShowException_Default_ShouldNotShowExceptionProperty(
+        public async Task ResponseWriter_HideExceptions_Default_ShouldShowExceptionsProperty(
             HealthReport healthReport)
         {
             // Arrange
             var httpContext = CreateHttpContext();
-
-            // Act
-            await RockLibHealthChecks.ResponseWriter(httpContext, healthReport);
-
-            // Assert
-            var jsonBody = await GetJsonBody(httpContext);
-            var healthCheckEntries = GetHealthCheckEntries(jsonBody);
-
-            healthCheckEntries
-                .Any(x => x["exception"] != null)
-                .Should()
-                .BeFalse();
-        }
-
-        [Theory]
-        [AutoData]
-        public async Task ResponseWriter_ShowException_SetToFalse_ShouldNotShowExceptionProperty(
-            HealthReport healthReport)
-        {
-            // Arrange
-            var httpContext = CreateHttpContext();
-            RockLibHealthChecks.ShowExceptions = false;
-
-            // Act
-            await RockLibHealthChecks.ResponseWriter(httpContext, healthReport);
-
-            // Assert
-            var jsonBody = await GetJsonBody(httpContext);
-            var healthCheckEntries = GetHealthCheckEntries(jsonBody);
-
-            healthCheckEntries
-                .Any(x => x["exception"] != null)
-                .Should()
-                .BeFalse();
-        }
-
-        [Theory]
-        [AutoData]
-        public async Task ResponseWriter_ShowException_SetToTrue_ShouldShowExceptionProperty(
-            HealthReport healthReport)
-        {
-            // Arrange
-            var httpContext = CreateHttpContext();
-            RockLibHealthChecks.ShowExceptions = true;
 
             // Act
             await RockLibHealthChecks.ResponseWriter(httpContext, healthReport);
@@ -76,6 +32,50 @@ namespace RockLib.HealthChecks.AspNetCore.ResponseWriter.Tests
                 .Any(x => x["exception"] != null)
                 .Should()
                 .BeTrue();
+        }
+
+        [Theory]
+        [AutoData]
+        public async Task ResponseWriter_HideExceptions_SetToFalse_ShouldShowExceptionsProperty(
+            HealthReport healthReport)
+        {
+            // Arrange
+            var httpContext = CreateHttpContext();
+            RockLibHealthChecks.HideExceptions = false;
+
+            // Act
+            await RockLibHealthChecks.ResponseWriter(httpContext, healthReport);
+
+            // Assert
+            var jsonBody = await GetJsonBody(httpContext);
+            var healthCheckEntries = GetHealthCheckEntries(jsonBody);
+
+            healthCheckEntries
+                .Any(x => x["exception"] != null)
+                .Should()
+                .BeTrue();
+        }
+
+        [Theory]
+        [AutoData]
+        public async Task ResponseWriter_HideExceptions_SetToTrue_ShouldHideExceptionsProperty(
+            HealthReport healthReport)
+        {
+            // Arrange
+            var httpContext = CreateHttpContext();
+            RockLibHealthChecks.HideExceptions = true;
+
+            // Act
+            await RockLibHealthChecks.ResponseWriter(httpContext, healthReport);
+
+            // Assert
+            var jsonBody = await GetJsonBody(httpContext);
+            var healthCheckEntries = GetHealthCheckEntries(jsonBody);
+
+            healthCheckEntries
+                .Any(x => x["exception"] != null)
+                .Should()
+                .BeFalse();
         }
 
         [Theory]

--- a/Tests/RockLib.HealthChecks.AspNetCore.ResponseWriter.Tests/RockLib.HealthChecks.AspNetCore.ResponseWriter.Tests.csproj
+++ b/Tests/RockLib.HealthChecks.AspNetCore.ResponseWriter.Tests/RockLib.HealthChecks.AspNetCore.ResponseWriter.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net462;</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.15.0" />
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.15.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="Moq" Version="4.16.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\RockLib.HealthChecks.AspNetCore.ResponseWriter\RockLib.HealthChecks.AspNetCore.ResponseWriter.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/docs/ResponseWriter.md
+++ b/docs/ResponseWriter.md
@@ -36,8 +36,8 @@ Since the response writer doesn't have a way to pass in the usual RockLib option
 Property               | Default Value      | Description
 ---------------------- | ------------------ | -----------
 Indent                 | `false`            | Gets or sets a value indicating whether the `ResponseWriter` delegate will indent its JSON output.
-ShowOutputs            | `false`            | Gets or sets a value indicating whether the `ResponseWriter` delegate will hide the output property in its JSON output.
-HideExceptions         | `false`            | Gets or sets a value indicating whether the `ResponseWriter` delegate will display the exception property in its JSON output.
+HideOutputs            | `false`            | Gets or sets a value indicating whether the `ResponseWriter` delegate will hide the output property in its JSON output.
+HideExceptions         | `false`            | Gets or sets a value indicating whether the `ResponseWriter` delegate will hide the exception property in its JSON output.
 
 This can be done in the 'Startup.cs'
 
@@ -48,7 +48,7 @@ public class Startup
     {
         RockLibHealthChecks.Indent = true;
         RockLibHealthChecks.HideOutputs = true;
-        RockLibHealthChecks.ShowExceptions = true;
+        RockLibHealthChecks.HideExceptions = true;
 
         app.UseHealthChecks("/health", new HealthCheckOptions
         {

--- a/docs/ResponseWriter.md
+++ b/docs/ResponseWriter.md
@@ -36,6 +36,8 @@ Since the response writer doesn't have a way to pass in the usual RockLib option
 Property               | Default Value      | Description
 ---------------------- | ------------------ | -----------
 Indent                 | `false`            | Gets or sets a value indicating whether the `ResponseWriter` delegate will indent its JSON output.
+ShowOutputs            | `false`            | Gets or sets a value indicating whether the `ResponseWriter` delegate will hide the output property in its JSON output.
+HideExceptions         | `false`            | Gets or sets a value indicating whether the `ResponseWriter` delegate will display the exception property in its JSON output.
 
 This can be done in the 'Startup.cs'
 
@@ -45,6 +47,8 @@ public class Startup
     public void Configure(IApplicationBuilder app, IHostingEnvironment env)
     {
         RockLibHealthChecks.Indent = true;
+        RockLibHealthChecks.HideOutputs = true;
+        RockLibHealthChecks.ShowExceptions = true;
 
         app.UseHealthChecks("/health", new HealthCheckOptions
         {


### PR DESCRIPTION
I'd like to hide the internal workings of the service that is returning health statuses.  To do this I need to hide the output and exception.

To make it backwards compatible, I've written it so the default is to include the output and exception property.

I think it would be best to hide the exception by default and display output by default but this would have been a breaking change.

If you would like me to change the Exception so that it is hidden by default, please let me know :) 