### PR TITLE
Switch underscore and dotted config section names

### DIFF
--- a/RockLib.HealthChecks/HealthCheck.cs
+++ b/RockLib.HealthChecks/HealthCheck.cs
@@ -74,7 +74,7 @@ namespace RockLib.HealthChecks
             var healtchChecksSection = (RockLibHealthChecksSection)ConfigurationManager.GetSection("rockLib.healthChecks");
             return healtchChecksSection.CreateRunners();
 #else
-            var section = Config.Root.GetCompositeSection("RockLib.HealthChecks", "RockLib_HealthChecks");
+            var section = Config.Root.GetCompositeSection("RockLib_HealthChecks", "RockLib.HealthChecks");
             return section.Create<IReadOnlyListOfIHealthCheckRunner>();
 #endif
         }


### PR DESCRIPTION
## Description

This is to make the library consistent with our other libraries - they all check the underscore name before the dotted name.

## Type of change: 4 (though I don't thing anyone is using the library in a way that this change would actually break them)

1. Non-functional change (e.g. documentation changes, removing unused `using` directives, renaming local variables, etc)
2. Bug fix (non-breaking change that fixes an issue)
3. New feature (non-breaking change that adds functionality)
4. Breaking change (fix or feature that could cause existing functionality to not work as expected)

## Checklist:

- Have you reviewed your own code? Do you understand every change?
- Are you following the [contributing guidelines](../blob/main/CONTRIBUTING.md)?
- Have you added tests that prove your fix is effective or that this feature works?
- New and existing unit tests pass locally with these changes?
- Have you made corresponding changes to the documentation?
- Will this change require an update to an example project? (if so, create an issue and link to it)

---

<sup>_[Reviewer guidelines](../blob/main/CONTRIBUTING.md#reviewing-changes)_</sup>
