### PR TITLE
Update to .NET 8 and Remove .NET Core 3.1

### DIFF
--- a/RockLib.HealthChecks.AspNetCore.ResponseWriter/CHANGELOG.md
+++ b/RockLib.HealthChecks.AspNetCore.ResponseWriter/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.0.0-alpha.1 - 2024-02-27
+
+#### Changed
+- Removed netcoreapp3.1 from supported targets from test project.
+- Added net8.0 to supported targets to test project.
+- Updated package references in test project.
+
 ## 2.0.0-alpha.2 - 2023-03-01
 
 #### Changed

--- a/RockLib.HealthChecks.AspNetCore/CHANGELOG.md
+++ b/RockLib.HealthChecks.AspNetCore/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 4.0.0-alpha.3 - 2024-02-27
+
+#### Changed
+- Removed netcoreapp3.1 from supported targets from test project.
+- Added net8.0 to supported targets to test project.
+- Updated package references in test project.
+
 ## 4.0.0-alpha.2 - 2024-02-27
 
 #### Changed

--- a/RockLib.HealthChecks.AspNetCore/RockLib.HealthChecks.AspNetCore.csproj
+++ b/RockLib.HealthChecks.AspNetCore/RockLib.HealthChecks.AspNetCore.csproj
@@ -11,9 +11,9 @@
 		<PackageReleaseNotes>A changelog is available at https://github.com/RockLib/RockLib.HealthChecks/blob/main/RockLib.HealthChecks.AspNetCore/CHANGELOG.md.</PackageReleaseNotes>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<PackageTags>rocklib health checks aspnetcore middleware</PackageTags>
-		<PackageVersion>4.0.0-alpha.2</PackageVersion>
+		<PackageVersion>4.0.0-alpha.3</PackageVersion>
 		<PublishRepositoryUrl>True</PublishRepositoryUrl>
-		<Version>4.0.0-alpha.2</Version>
+		<Version>4.0.0-alpha.3</Version>
 	</PropertyGroup>
 	<PropertyGroup>
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(PackageId).xml</DocumentationFile>
@@ -24,7 +24,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-		<PackageReference Include="RockLib.HealthChecks" Version="2.0.1" />
+		<PackageReference Include="RockLib.HealthChecks" Version="3.0.0-alpha.1" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 	</ItemGroup>
 	<ItemGroup>

--- a/RockLib.HealthChecks.Client/CHANGELOG.md
+++ b/RockLib.HealthChecks.Client/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.0-alpha.1 - 2024-02-29
+
+#### Changed
+- Removed netcoreapp3.1 from supported targets from test project.
+- Added net8.0 to supported targets to test project.
+- Updated package references in test project.
+
 ## 1.0.0 - 2022-03-03
 	
 #### Added

--- a/RockLib.HealthChecks.Client/Directory.Build.props
+++ b/RockLib.HealthChecks.Client/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
-	<PropertyGroup Condition=" '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'netcoreapp3.1'">
+	<PropertyGroup Condition=" '$(TargetFramework)' == 'net48'">
 		<EnableNETAnalyzers>true</EnableNETAnalyzers>
 	</PropertyGroup>
 	<PropertyGroup>
@@ -8,12 +8,12 @@
 		<Copyright>Copyright 2022 (c) Rocket Mortgage. All rights reserved.</Copyright>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
-		<TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
+		<TargetFrameworks>net6.0;net8.0;net48</TargetFrameworks>
 		<NoWarn>NU1603,NU1701</NoWarn>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'netcoreapp3.1'">
-		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net48'">
+		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/RockLib.HealthChecks.Client/RockLib.HealthChecks.Client.csproj
+++ b/RockLib.HealthChecks.Client/RockLib.HealthChecks.Client.csproj
@@ -11,9 +11,9 @@
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<PackageReleaseNotes>A changelog is available at https://github.com/RockLib/RockLib.HealthChecks/blob/main/RockLib.HealthChecks.Client/CHANGELOG.md.</PackageReleaseNotes>
 		<PackageTags>rocklib health checks client</PackageTags>
-		<PackageVersion>1.0.0</PackageVersion>
+		<PackageVersion>2.0.0-alpha.1</PackageVersion>
 		<PublishRepositoryUrl>True</PublishRepositoryUrl>
-		<Version>1.0.0</Version>
+		<Version>2.0.0-alpha.1</Version>
 	</PropertyGroup>
 	<PropertyGroup>
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(PackageId).xml</DocumentationFile>
@@ -22,7 +22,7 @@
 		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="System.Text.Json" Version="6.0.2" />
+		<PackageReference Include="System.Text.Json" Version="8.0.2" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
 	</ItemGroup>
 	<ItemGroup>

--- a/RockLib.HealthChecks.WebApi/CHANGELOG.md
+++ b/RockLib.HealthChecks.WebApi/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.0.0-alpha.1 - 2024-02-29
+
+#### Changed
+- Removed netcoreapp3.1 from supported targets from test project.
+- Added net8.0 to supported targets to test project.
+- Updated package references in test project.
+
 ## 2.0.0-alpha.2 - 2023-03-02
 
 #### Changed

--- a/RockLib.HealthChecks.WebApi/Directory.Build.props
+++ b/RockLib.HealthChecks.WebApi/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
-	<PropertyGroup Condition=" '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'netcoreapp3.1'">
+	<PropertyGroup Condition=" '$(TargetFramework)' == 'net48'">
 		<EnableNETAnalyzers>true</EnableNETAnalyzers>
 	</PropertyGroup>
 	<PropertyGroup>
@@ -8,11 +8,11 @@
 		<Copyright>Copyright 2022 (c) Rocket Mortgage. All rights reserved.</Copyright>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
-		<TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
+		<TargetFrameworks>net6.0;net8.0;net48</TargetFrameworks>
 		<NoWarn>NU1603,NU1701</NoWarn>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'netcoreapp3.1'">
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net48'">
 		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/RockLib.HealthChecks.WebApi/RockLib.HealthChecks.WebApi.csproj
+++ b/RockLib.HealthChecks.WebApi/RockLib.HealthChecks.WebApi.csproj
@@ -23,8 +23,8 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-		<PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.9" />
-		<PackageReference Include="RockLib.HealthChecks" Version="2.0.1" />
+		<PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.3.0" />
+		<PackageReference Include="RockLib.HealthChecks" Version="3.0.0-alpha.1" />
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
 	</ItemGroup>

--- a/Tests/RockLib.HealthChecks.Client.Tests/Directory.Build.props
+++ b/Tests/RockLib.HealthChecks.Client.Tests/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
-	<PropertyGroup Condition=" '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'netcoreapp3.1'">
+	<PropertyGroup Condition=" '$(TargetFramework)' == 'net48'">
 		<EnableNETAnalyzers>true</EnableNETAnalyzers>
 	</PropertyGroup>
 	<PropertyGroup>
@@ -8,12 +8,12 @@
 		<Copyright>Copyright 2022 (c) Rocket Mortgage. All rights reserved.</Copyright>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
-		<TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
+		<TargetFrameworks>net6.0;net8.0;net48</TargetFrameworks>
 		<NoWarn>NU1603,NU1701</NoWarn>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'netcoreapp3.1'">
-		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net48'">
+		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/Tests/RockLib.HealthChecks.Client.Tests/RockLib.HealthChecks.Client.Tests.csproj
+++ b/Tests/RockLib.HealthChecks.Client.Tests/RockLib.HealthChecks.Client.Tests.csproj
@@ -6,13 +6,13 @@
 		<PackageReference Include="FluentAssertions" Version="6.5.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-		<PackageReference Include="System.Text.Json" Version="6.0.2" />
+		<PackageReference Include="System.Text.Json" Version="8.0.2" />
 		<PackageReference Include="xunit" Version="2.4.1" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="3.1.2">
+		<PackageReference Include="coverlet.collector" Version="6.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>


### PR DESCRIPTION
update target frameworks to remove .NET Core 3.1 and add .NET 8 for the following projects:

- RockLib.HealthChecks.AspNetCore
- RockLib.HealthChecks.AspNetCore.ResponseWriter
- RockLib.HealthChecks.Client
- RockLib.HealthChecks.WebApi