### PR TITLE
Update to .NET 8 and Remove .NET Core 3.1 - full release

### DIFF
--- a/RockLib.HealthChecks.AspNetCore.ResponseWriter/CHANGELOG.md
+++ b/RockLib.HealthChecks.AspNetCore.ResponseWriter/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.0.0 - 2024-03-04
+
+#### Changed
+- Removed netcoreapp3.1 from supported targets.
+- Added net8.0 to supported targets.
+- Updated package references.
+
 ## 3.0.0-alpha.1 - 2024-02-27
 
 #### Changed

--- a/RockLib.HealthChecks.AspNetCore.ResponseWriter/RockLib.HealthChecks.AspNetCore.ResponseWriter.csproj
+++ b/RockLib.HealthChecks.AspNetCore.ResponseWriter/RockLib.HealthChecks.AspNetCore.ResponseWriter.csproj
@@ -11,9 +11,9 @@
 		<PackageReleaseNotes>A changelog is available at https://github.com/RockLib/RockLib.HealthChecks/blob/main/RockLib.HealthChecks.AspNetCore.ResponseWriter/CHANGELOG.md.</PackageReleaseNotes>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<PackageTags>rocklib health checks aspnetcore responsewriter</PackageTags>
-		<PackageVersion>3.0.0-alpha.1</PackageVersion>
+		<PackageVersion>3.0.0</PackageVersion>
 		<PublishRepositoryUrl>True</PublishRepositoryUrl>
-		<Version>3.0.0-alpha.1</Version>
+		<Version>3.0.0</Version>
 	</PropertyGroup>
 	<PropertyGroup>
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(PackageId).xml</DocumentationFile>

--- a/RockLib.HealthChecks.AspNetCore/CHANGELOG.md
+++ b/RockLib.HealthChecks.AspNetCore/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 4.0.0 - 2024-03-04
+
+#### Changed
+- Removed netcoreapp3.1 from supported targets.
+- Added net8.0 to supported targets.
+- Updated package references.
+
 ## 4.0.0-alpha.3 - 2024-02-27
 
 #### Changed

--- a/RockLib.HealthChecks.AspNetCore/RockLib.HealthChecks.AspNetCore.csproj
+++ b/RockLib.HealthChecks.AspNetCore/RockLib.HealthChecks.AspNetCore.csproj
@@ -11,9 +11,9 @@
 		<PackageReleaseNotes>A changelog is available at https://github.com/RockLib/RockLib.HealthChecks/blob/main/RockLib.HealthChecks.AspNetCore/CHANGELOG.md.</PackageReleaseNotes>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<PackageTags>rocklib health checks aspnetcore middleware</PackageTags>
-		<PackageVersion>4.0.0-alpha.3</PackageVersion>
+		<PackageVersion>4.0.0</PackageVersion>
 		<PublishRepositoryUrl>True</PublishRepositoryUrl>
-		<Version>4.0.0-alpha.3</Version>
+		<Version>4.0.0</Version>
 	</PropertyGroup>
 	<PropertyGroup>
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(PackageId).xml</DocumentationFile>

--- a/RockLib.HealthChecks.Client/CHANGELOG.md
+++ b/RockLib.HealthChecks.Client/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.0 - 2024-03-04
+
+#### Changed
+- Removed netcoreapp3.1 from supported targets.
+- Added net8.0 to supported targets.
+- Updated package references.
+
 ## 2.0.0-alpha.1 - 2024-02-29
 
 #### Changed

--- a/RockLib.HealthChecks.Client/RockLib.HealthChecks.Client.csproj
+++ b/RockLib.HealthChecks.Client/RockLib.HealthChecks.Client.csproj
@@ -11,9 +11,9 @@
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<PackageReleaseNotes>A changelog is available at https://github.com/RockLib/RockLib.HealthChecks/blob/main/RockLib.HealthChecks.Client/CHANGELOG.md.</PackageReleaseNotes>
 		<PackageTags>rocklib health checks client</PackageTags>
-		<PackageVersion>2.0.0-alpha.1</PackageVersion>
+		<PackageVersion>2.0.0</PackageVersion>
 		<PublishRepositoryUrl>True</PublishRepositoryUrl>
-		<Version>2.0.0-alpha.1</Version>
+		<Version>2.0.0</Version>
 	</PropertyGroup>
 	<PropertyGroup>
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(PackageId).xml</DocumentationFile>

--- a/RockLib.HealthChecks.HttpModule/CHANGELOG.md
+++ b/RockLib.HealthChecks.HttpModule/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.0 - 2024-03-04
+
+#### Changed
+- Removed netcoreapp3.1 from supported targets.
+- Added net8.0 to supported targets.
+- Updated package references.
+
 ## 2.0.0-alpha.2 - 2023-03-02
 
 #### Changed

--- a/RockLib.HealthChecks.HttpModule/RockLib.HealthChecks.HttpModule.csproj
+++ b/RockLib.HealthChecks.HttpModule/RockLib.HealthChecks.HttpModule.csproj
@@ -11,14 +11,14 @@
 		<PackageReleaseNotes>A changelog is available at https://github.com/RockLib/RockLib.HealthChecks/blob/main/RockLib.HealthChecks.HttpModule/CHANGELOG.md.</PackageReleaseNotes>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<PackageTags>rocklib health checks httpmodule</PackageTags>
-		<PackageVersion>2.0.0-alpha.2</PackageVersion>
+		<PackageVersion>2.0.0</PackageVersion>
 		<PublishRepositoryUrl>True</PublishRepositoryUrl>
 		<!--
 		IHttpModule is only for .NET Framework, so there is no need to target any other frameworks.
 		https://learn.microsoft.com/en-us/dotnet/api/system.web.ihttpmodule?view=netframework-4.8
 		-->
 		<TargetFramework>net48</TargetFramework>
-		<Version>2.0.0-alpha.2</Version>
+		<Version>2.0.0</Version>
 	</PropertyGroup>
 	<PropertyGroup>
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(PackageId).xml</DocumentationFile>

--- a/RockLib.HealthChecks.WebApi/CHANGELOG.md
+++ b/RockLib.HealthChecks.WebApi/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.0.0 - 2024-03-04
+
+#### Changed
+- Removed netcoreapp3.1 from supported targets.
+- Added net8.0 to supported targets.
+- Updated package references.
+
 ## 3.0.0-alpha.1 - 2024-02-29
 
 #### Changed

--- a/RockLib.HealthChecks.WebApi/RockLib.HealthChecks.WebApi.csproj
+++ b/RockLib.HealthChecks.WebApi/RockLib.HealthChecks.WebApi.csproj
@@ -10,10 +10,10 @@
 		<PackageReleaseNotes>A changelog is available at https://github.com/RockLib/RockLib.HealthChecks/blob/main/RockLib.HealthChecks.WebApi/CHANGELOG.md.</PackageReleaseNotes>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<PackageTags>rocklib health checks webapi</PackageTags>
-		<PackageVersion>3.0.0-alpha.1</PackageVersion>
+		<PackageVersion>3.0.0</PackageVersion>
 		<PackageIcon>icon.png</PackageIcon>
 		<PublishRepositoryUrl>True</PublishRepositoryUrl>
-		<Version>3.0.0-alpha.1</Version>
+		<Version>3.0.0</Version>
 	</PropertyGroup>
 	<PropertyGroup>
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(PackageId).xml</DocumentationFile>


### PR DESCRIPTION
release full versions of:

- RockLib.HealthChecks.AspNetCore
- RockLib.HealthChecks.AspNetCore.ResponseWriter
- RockLib.HealthChecks.Client
- RockLib.HealthChecks.HttpModule
- RockLib.HealthChecks.WebApi