### PR TITLE
Fix array index overrun via thread locking & modulo operation

### DIFF
--- a/Tests/RockLib.HealthChecks.AspNetCore.Tests/Collector/HealthMetricCollectorTests.cs
+++ b/Tests/RockLib.HealthChecks.AspNetCore.Tests/Collector/HealthMetricCollectorTests.cs
@@ -1,4 +1,7 @@
 ﻿using RockLib.HealthChecks.AspNetCore.Collector;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace RockLib.HealthChecks.AspNetCore.Tests.Collector;
@@ -12,13 +15,13 @@ public class HealthMetricCollectorTests
         collector.Collect(1);
         collector.Collect(2);
         collector.Collect(3);
-        var arr = new[] { 1, 2, 3 };
+        var arr = new[] { 3, 1, 2 };
         Assert.Equal(arr, collector.GetMetrics());
 
         // begin overwriting
         collector.Collect(4);
         collector.Collect(5);
-        arr = [4, 5, 3];
+        arr = [3, 4, 5];
         Assert.Equal(arr, collector.GetMetrics());
     }
 
@@ -38,5 +41,51 @@ public class HealthMetricCollectorTests
     {
         var collector = new HealthMetricCollector(3);
         Assert.Equal([], collector.GetMetrics(x => x == 4));
+    }
+
+    /// <summary>
+    /// This test is the antithesis of the next test.  It proves that the collector requires thread safety.
+    /// If this test ever starts failing we may no longer need to use Interlocked.Increment in the Collect method.
+    /// </summary>
+    [Fact]
+    public void ProofCollectorRequiresThreadSafety()
+    {
+        var collector = new HealthMetricCollector(3);
+
+        var stopwatch = new Stopwatch();
+        stopwatch.Start();
+        var cnt = 0;
+        var res = Parallel.For(0, 10, _ =>
+        {
+            while (stopwatch.ElapsedMilliseconds < 1000)
+            {
+                collector.Collect(1);
+                ++cnt; // unsafe; being accessed by multiple threads at once
+            }
+        });
+        stopwatch.Stop();
+        Assert.True(res.IsCompleted);
+        Assert.True(cnt < collector.GetImpressionCount());
+    }
+
+    [Fact]
+    public void HealthMetricCollectorIsThreadSafe()
+    {
+        var collector = new HealthMetricCollector(3);
+
+        var stopwatch = new Stopwatch();
+        stopwatch.Start();
+        var cnt = 0;
+        var res = Parallel.For(0, 100, _ =>
+        {
+            while (stopwatch.ElapsedMilliseconds < 2500)
+            {
+                collector.Collect(1);
+                Interlocked.Increment(ref cnt); // safe; leverages a locking mechanism
+            }
+        });
+        stopwatch.Stop();
+        Assert.True(res.IsCompleted);
+        Assert.Equal(collector.GetImpressionCount(), cnt);
     }
 }


### PR DESCRIPTION
## Description

We discovered a bug where an ArrayIndexOutOfBounds was being triggered when multiple threads hit the Collect method at the same time and the _index value was at the end of the array.  (It's actually quite easy to exploit!)  +1 on that caused the overrun, prior to executing the line of code to reset the pointer.  The solution was to use a lock to ensure the value was accessed sequentially.

A modulus operation was then introduced so we didn't have to lock multiple times (when a reset was needed), or over a larger block of code.  The proposed solution locks an ever-incrementing long, and the modulus of that (over the array size) tells us which array slot to put the data into.

## Type of change:

2. Bug fix (non-breaking change that fixes an issue)

## Checklist:

- Have you reviewed your own code? Do you understand every change? Y
- Are you following the [contributing guidelines](../blob/main/CONTRIBUTING.md)? Y
- Have you added tests that prove your fix is effective or that this feature works? Y
- New and existing unit tests pass locally with these changes? Y
- Have you made corresponding changes to the documentation? N/A
- Will this change require an update to an example project? (if so, create an issue and link to it) N

---

<sup>_[Reviewer guidelines](../blob/main/CONTRIBUTING.md#reviewing-changes)_</sup>
