### PR TITLE
Add direct dependency to System.Text.Encodings.Web 6.0.0

### DIFF
--- a/RockLib.HealthChecks.AspNetCore/RockLib.HealthChecks.AspNetCore.csproj
+++ b/RockLib.HealthChecks.AspNetCore/RockLib.HealthChecks.AspNetCore.csproj
@@ -28,6 +28,7 @@
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 		<PackageReference Include="RockLib.HealthChecks" Version="3.0.2" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<!--Remove this direct dependency with new framework updates-->
 		<PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
 	</ItemGroup>
 	<ItemGroup>

--- a/RockLib.HealthChecks.AspNetCore/RockLib.HealthChecks.AspNetCore.csproj
+++ b/RockLib.HealthChecks.AspNetCore/RockLib.HealthChecks.AspNetCore.csproj
@@ -28,6 +28,7 @@
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 		<PackageReference Include="RockLib.HealthChecks" Version="3.0.2" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<None Include="..\LICENSE.md" Pack="true" PackagePath="" />


### PR DESCRIPTION
## Description

Due to the differences in how .NET Framework and .NET build, there was a security issue in the .NET 6 and .NET 8 versions of the package. This takes a direct dependency to resolve that. 

## Type of change: <!-- Choose the highest number that applies -->

**2. Bug fix (non-breaking change that fixes an issue)**

## Checklist:

- Have you reviewed your own code? Do you understand every change?
- Are you following the [contributing guidelines](../blob/main/CONTRIBUTING.md)?
- Have you added tests that prove your fix is effective or that this feature works?
- New and existing unit tests pass locally with these changes?
- Have you made corresponding changes to the documentation?
- Will this change require an update to an example project? (if so, create an issue and link to it)

---

<sup>_[Reviewer guidelines](../blob/main/CONTRIBUTING.md#reviewing-changes)_</sup>
